### PR TITLE
Addressing a few bugs related to HTTPS

### DIFF
--- a/medea/__init__.py
+++ b/medea/__init__.py
@@ -24,7 +24,7 @@ firstFalseByte = const(102)     # ord('f')
 firstNullByte = const(110)      # ord('n')
 minusByte = const(45)           # ord('-')
 
-numberMetaBytes = b'.xeEb' # non-digit characters allowable in numbers
+numberMetaBytes = b'-+.xeEb' # non-digit characters allowable in numbers
 spaceBytes = b' \n\t\r'
 digitBytes = b'0123456789'
 

--- a/medea/https.py
+++ b/medea/https.py
@@ -18,7 +18,7 @@ def generateResponseBytes(url, headers=None, timeout=1.0, buf=None, bufferSize=d
     if hasattr(s, 'settimeout'):
         s.settimeout(timeout)
     try:
-        s = ssl.wrap_socket(s)
+        s = ssl.wrap_socket(s, server_hostname=host)
         s.write(b'GET /')
         s.write(path.encode('ascii'))
         s.write(b' HTTP/1.1\r\nHost: ')

--- a/medea/https.py
+++ b/medea/https.py
@@ -1,6 +1,6 @@
 import sys
 import gc
-from medea import defaultBufferSize
+from medea import defaultBufferSize, Tokenizer
 from medea.agnostic import socket, ssl, SocketTimeoutError
 
 def generateResponseBytes(url, headers=None, timeout=1.0, buf=None, bufferSize=defaultBufferSize):
@@ -110,3 +110,7 @@ def generateContentBytes(*a, **k):
     contentLength = processHttpHeaders(byteGenerator)
     byteGenerator.send(contentLength)
     yield from byteGenerator
+
+def tokenizeContent(*a, **k):
+    tokenizer = Tokenizer()
+    yield from tokenizer.tokenizeValue(generateContentBytes(*a, **k))


### PR DESCRIPTION
To get this module working with HTTPS requests, I had to fix 2 bugs:

- Addressed issue #5: for me, this was fixed by adding `server_hostname=host` to the `s = ssl.wrap_socket` call.
- Added `-+` to `numberMetaBytes`, to correctly parse floats like `5.972168e+24`.

In the meantime, I added a `tokenizeContent` function, to increase parity between functionality in `https.py` and `file.py`.